### PR TITLE
++ should only aggregate compatible projects

### DIFF
--- a/src/sbt-test/sbt-doge/override/test
+++ b/src/sbt-test/sbt-doge/override/test
@@ -12,3 +12,27 @@ $ exists lib/target/scala-2.11
 $ exists lib/target/scala-2.10
 -$ exists sbt-foo/target/scala-2.10
 -$ exists sbt-foo/target/scala-2.11
+
+> clean
+> +++2.11.1 compile
+
+$ exists lib/target/scala-2.11
+-$ exists lib/target/scala-2.10
+-$ exists sbt-foo/target/scala-2.10
+-$ exists sbt-foo/target/scala-2.11
+
+> clean
+> +++2.10.4 compile
+
+-$ exists lib/target/scala-2.11
+$ exists lib/target/scala-2.10
+$ exists sbt-foo/target/scala-2.10
+-$ exists sbt-foo/target/scala-2.11
+
+> clean
+> +++2.11.5 compile
+
+$ exists lib/target/scala-2.11
+-$ exists lib/target/scala-2.10
+-$ exists sbt-foo/target/scala-2.10
+-$ exists sbt-foo/target/scala-2.11


### PR DESCRIPTION
This PR depends on #3 being merged first.

When a user does:

    ++2.11.5 compile

Currently we build all projects with 2.11.5, regardless of whether they support it or not.  This change means that in that situation, we only build projects that are configured to cross build against a Scala version that is binary compatible with 2.11.5.

Of course, another way to achieve this would be to first switch to a dummy project that only aggregated projects that support that version, but this negates that need to have such a dummy project.

Of course, this doesn't work if you:

    ++2.11.5
    compile

But it's convenient.  If a project is specified, then it builds it regardless of the support - perhaps we could make that an error though.