### PR TITLE
Allowed concurrent execution of commands on projects

### DIFF
--- a/src/sbt-test/sbt-doge/concurrent/build.sbt
+++ b/src/sbt-test/sbt-doge/concurrent/build.sbt
@@ -1,0 +1,37 @@
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicBoolean
+
+lazy val latch = new CountDownLatch(2)
+
+lazy val running = new AtomicBoolean(false)
+
+lazy val countDown = TaskKey[Unit]("countDownAndBlock") := {
+  latch.countDown()
+  if (!latch.await(2, TimeUnit.SECONDS)) {
+    sys.error("Count down timed out, the tasks must not have executed in parallel!")
+  }
+}
+
+// This tries to detect concurrent execution when there shouldn't be
+lazy val runExclusive = InputKey[Unit]("runExclusive") := {
+  val args = Def.spaceDelimited("<arg>").parsed
+  if (args.isEmpty) sys.error("no arguments supplied")
+  if (running.getAndSet(true)) sys.error("already running")
+  Thread.sleep(1000)
+  running.set(false)
+}
+
+lazy val rootProj = (project in file("."))
+  .enablePlugins(CrossPerProjectPlugin)
+  .aggregate(a, b)
+
+lazy val a = (project in file("a")).settings(
+  countDown,
+  runExclusive
+)
+
+lazy val b = (project in file("b")).settings(
+  countDown,
+  runExclusive
+)
+

--- a/src/sbt-test/sbt-doge/concurrent/project/doge.sbt
+++ b/src/sbt-test/sbt-doge/concurrent/project/doge.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.eed3si9n" % "sbt-doge" % pluginVersion)
+}

--- a/src/sbt-test/sbt-doge/concurrent/test
+++ b/src/sbt-test/sbt-doge/concurrent/test
@@ -1,0 +1,4 @@
+# This test might fail if there's only one available processor...
+> +countDownAndBlock
+
+> +runExclusive now


### PR DESCRIPTION
This disptaches aggregated commands on projects concurrently using the all command for each scala version, instead of one at a time.

Note though that this does represent a change in behaviour, specifically, since the all command splits tasks by spaces, and doesn't support quoting tasks, it means that cross build commands can't contain spaces.

Also, the scripted tests proves it works, but may fail if you run it on a single processor machine.  Not sure if that's ok or not.