### PR TITLE
Updated simple test so it doesn't use its own cache

### DIFF
--- a/src/sbt-test/sbt-doge/simple/build.sbt
+++ b/src/sbt-test/sbt-doge/simple/build.sbt
@@ -1,15 +1,8 @@
-def commonSettings: Seq[Def.Setting[_]] = Seq(
-  organization := "com.example.doge",
-  version := "0.1-SNAPSHOT",
-  ivyPaths := new IvyPaths((baseDirectory in ThisBuild).value, Some((baseDirectory in ThisBuild).value / "ivy-cache"))
-)
 
 lazy val rootProj = (project in file(".")).
-  aggregate(libProj, fooPlugin).
-  settings(commonSettings: _*)
+  aggregate(libProj, fooPlugin)
 
 lazy val libProj = (project in file("lib")).
-  settings(commonSettings: _*).
   settings(
     name := "foo-lib",
     scalaVersion := "2.11.1",
@@ -17,7 +10,6 @@ lazy val libProj = (project in file("lib")).
   )
 
 lazy val fooPlugin =(project in file("sbt-foo")).
-  settings(commonSettings: _*).
   settings(
     name := "sbt-foo",
     sbtPlugin := true,

--- a/src/sbt-test/sbt-doge/simple/test
+++ b/src/sbt-test/sbt-doge/simple/test
@@ -1,5 +1,38 @@
-> ;so clean; such test; very publishLocal
+> ;so clean; such compile; very test
 
-$ exists ivy-cache/local/com.example.doge/foo-lib_2.11/0.1-SNAPSHOT/jars/foo-lib_2.11.jar
-$ exists ivy-cache/local/com.example.doge/foo-lib_2.10/0.1-SNAPSHOT/jars/foo-lib_2.10.jar
-$ exists ivy-cache/local/com.example.doge/sbt-foo/scala_2.10/sbt_0.13/0.1-SNAPSHOT/jars/sbt-foo.jar
+$ exists lib/target/scala-2.11
+$ exists lib/target/scala-2.10
+$ exists sbt-foo/target/scala-2.10
+-$ exists sbt-foo/target/scala-2.11
+
+> clean
+> so libProj/compile
+
+$ exists lib/target/scala-2.11
+$ exists lib/target/scala-2.10
+-$ exists sbt-foo/target/scala-2.10
+-$ exists sbt-foo/target/scala-2.11
+
+> clean
+> plz 2.11.1 compile
+
+$ exists lib/target/scala-2.11
+-$ exists lib/target/scala-2.10
+-$ exists sbt-foo/target/scala-2.10
+-$ exists sbt-foo/target/scala-2.11
+
+> clean
+> plz 2.10.4 compile
+
+-$ exists lib/target/scala-2.11
+$ exists lib/target/scala-2.10
+$ exists sbt-foo/target/scala-2.10
+-$ exists sbt-foo/target/scala-2.11
+
+> clean
+> plz 2.11.5 compile
+
+$ exists lib/target/scala-2.11
+-$ exists lib/target/scala-2.10
+-$ exists sbt-foo/target/scala-2.10
+-$ exists sbt-foo/target/scala-2.11


### PR DESCRIPTION
Running the simple scripted test took a long time because it used its own ivy cache, and so had to download all dependencies manually.  This changes that so it now uses just the compile task, and checks for target/scala-n.